### PR TITLE
Adds support for Jaccard bag/multiset semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The previously described data can easily be converted into Spark's SparseVector 
 
 - *minClusterSize* - a post processing filter function that excludes clusters below a threshold.
 
+- *repeatedItems* - optional boolean value to indicate whether there are repeated items in each set and you want to use [multisets](https://en.wikipedia.org/wiki/Multiset) for computing Jaccard similarity. Defaults to false. Note that, when using bag semantics/multisets, the maximum possible similarity value for any two sets is 0.5 rather than 1. See [Mining of Massive Datasets](http://mmds.org/) chapter 3 pgs. 76-77 for more details.
+
 There are two ways to execute LSH. The first being a driver class that is submitted to a spark cluster (can be a single machine running in local mode). The second is using spark's REPL. The later is useful for parameter tuning. 
 
 

--- a/src/main/scala/com/invincea/spark/hash/LSHModel.scala
+++ b/src/main/scala/com/invincea/spark/hash/LSHModel.scala
@@ -6,7 +6,7 @@ import scala.collection.mutable.ListBuffer
 import org.apache.spark.SparkContext._
 
 
-class LSHModel(p : Int, m : Int, numRows : Int) extends Serializable {
+class LSHModel(p : Int, m : Int, numRows : Int, repeatedItems : Boolean = false) extends Serializable {
   
   /** generate rows hash functions */
   private val _hashFunctions = ListBuffer[Hasher]()
@@ -31,6 +31,9 @@ class LSHModel(p : Int, m : Int, numRows : Int) extends Serializable {
  
   /** jaccard cluster scores */
   var scores : RDD[(Long, Double)] = null
+
+  /** whether each vector has repeated items */
+  var hasRepeatedItems : Boolean = repeatedItems
   
   /** filter out scores below threshold. this is an optional step.*/
   def filter(score : Double) : LSHModel = {

--- a/src/test/scala/com/invincea/spark/hash/LSHSuite.scala
+++ b/src/test/scala/com/invincea/spark/hash/LSHSuite.scala
@@ -36,4 +36,30 @@ class LSHSuite extends FunSuite with LocalSparkContext {
     assert(model.filter(0.85).clusters.count() == 1)
     
   }
+  test("repeated items test") {
+
+
+    // suppose each key represents a movie and the value is a rating
+    val ratings = List(List((47,5.0), (33,2.0), (54,1.0), (23,5.0)),
+                       List((47,5.0), (33,2.0), (54,1.0), (23,4.0), (92,1.0)),
+                       List((54,3.0), (123,5.0), (82,1.0), (536,3.0), (92,3.0), (101,2.0)),
+                       List((45,2.0), (46,5.0), (47,4.0), (50,1.0), (54,2.0), (75,5.0), (23,4.0), (82,2.0)))
+
+    val rdd = sc.parallelize(ratings)
+
+    // make sure we have 4
+    assert(rdd.count() == 4)
+
+    val vctr = rdd.map(a => Vectors.sparse(1000, a).asInstanceOf[SparseVector])
+
+    val lsh = new LSH(data = vctr, p = 1019, m = 1000, numRows = 1000, numBands = 100, minClusterSize = 2, repeatedItems = true)
+    val model = lsh.run
+
+    // this should return 1 cluster
+    assert(model.clusters.count() == 1)
+
+    // The cluster similarity should be greater than 0.45 (0.462 exactly)
+    // The limit on jaccard similarity using bag semantics is 0.5, so this is actually very high
+    assert(model.filter(0.45).clusters.count() == 1)
+  }
 }


### PR DESCRIPTION
This commit adds support for calculating Jaccard similarity using
bag/multiset semantics, as described on pgs. 76-77 in chapter 3 of
Mining of Massive Datasets (MMDS).

MMDS uses the example of movie ratings:

> If ratings are 1-to-5-stars, put a movie in a customer's set n times
> if they rated the movie n-stars. Then, use Jaccard similarity for bags
> when measuring the similarity of customers. The Jaccard similarity for
> bags B and C is defined by counting an element n times in the
> intersection if n is the minimum of the number of times the element
> appears in B and C. In the union, we count the element the sum of the
> number of times it appears in B and C.

To fit a model using bag semantics, the user:
- Instantiates an LSH model with the variable repeatedItems set to
  true. This is an optional variable that is false by default.
- Passes their data into the model as a List or RDD of SparseVectors,
  where the indices of each SparseVector correspond to the distinct
items in the set, and the values of each correspond to the number of
times each corresponding item is repeated in the set.

The only difference in running the model and getting output is that the
Jaccard similarity between two sets with bag semantics has a maximum of
0.5 rather than 1.0.